### PR TITLE
keydir: avoid defers

### DIFF
--- a/internal/keydir.go
+++ b/internal/keydir.go
@@ -42,17 +42,15 @@ func (k *Keydir) Add(key string, fileid int, offset, size int64) Item {
 
 func (k *Keydir) Get(key string) (Item, bool) {
 	k.RLock()
-	defer k.RUnlock()
-
 	item, ok := k.kv[key]
+	k.RUnlock()
 	return item, ok
 }
 
 func (k *Keydir) Delete(key string) {
 	k.Lock()
-	defer k.Unlock()
-
 	delete(k.kv, key)
+	k.Unlock()
 }
 
 func (k *Keydir) Len() int {
@@ -63,11 +61,11 @@ func (k *Keydir) Keys() chan string {
 	ch := make(chan string)
 	go func() {
 		k.RLock()
-		defer k.RUnlock()
 		for key := range k.kv {
 			ch <- key
 		}
 		close(ch)
+		k.RUnlock()
 	}()
 	return ch
 }


### PR DESCRIPTION
This PR is a exploration of avoiding `defer` in hot-paths such as `keydir.Get`.
The use of `defer` has a runtime cost due to its mechanics of stacking function calls when the current functions ends.

Generally it's wise to use it in order to make the code more readable when multiple defers needs might be possible due to unpredictable code paths, making the code clearer and less error-prone.

Just to measure the impact of `defer` in a particular hot-path such as `keydir.Get` function, I made some tweaks and compare the results.

The code change is quite simple: avoid `defer`, then running `go test -test.run -benchmem -benchtime=5s -bench=BenchmarkGet`.
The flag `benchtime` was set to be a little more sure about result reliability; bigger values have similar results.

The changes also do the same on other `keydir` functions, but here are the results for the `.Get` benchmarks.

Running bench on `master`:
```
goos: linux
goarch: amd64
pkg: github.com/prologic/bitcask
BenchmarkGet/128B-8         	 5000000	      1402 ns/op	  91.25 MB/s
BenchmarkGet/256B-8         	 5000000	      1521 ns/op	 168.20 MB/s
BenchmarkGet/512B-8         	 5000000	      1836 ns/op	 278.82 MB/s
BenchmarkGet/1K-8           	 3000000	      2393 ns/op	 427.90 MB/s
BenchmarkGet/2K-8           	 2000000	      3364 ns/op	 608.78 MB/s
BenchmarkGet/4K-8           	 1000000	      5413 ns/op	 756.60 MB/s
BenchmarkGet/8K-8           	 1000000	      9116 ns/op	 898.63 MB/s
BenchmarkGet/16K-8          	  500000	     15947 ns/op	1027.37 MB/s
BenchmarkGet/32K-8          	  200000	     33585 ns/op	 975.67 MB/s
PASS
ok  	github.com/prologic/bitcask	78.404s
```

Running bench on changed code:
```
goos: linux
goarch: amd64
pkg: github.com/prologic/bitcask
BenchmarkGet/128B-8         	 5000000	      1367 ns/op	  93.61 MB/s
BenchmarkGet/256B-8         	 5000000	      1481 ns/op	 172.82 MB/s
BenchmarkGet/512B-8         	 5000000	      1776 ns/op	 288.26 MB/s
BenchmarkGet/1K-8           	 3000000	      2306 ns/op	 444.01 MB/s
BenchmarkGet/2K-8           	 2000000	      3264 ns/op	 627.40 MB/s
BenchmarkGet/4K-8           	 1000000	      5184 ns/op	 790.00 MB/s
BenchmarkGet/8K-8           	 1000000	      8911 ns/op	 919.31 MB/s
BenchmarkGet/16K-8          	  500000	     15842 ns/op	1034.19 MB/s
BenchmarkGet/32K-8          	  200000	     32416 ns/op	1010.85 MB/s
PASS
ok  	github.com/prologic/bitcask	76.498s
```
Comparison:
```
benchmark               old ns/op     new ns/op     delta
BenchmarkGet/128B-8     1402          1367          -2.50%
BenchmarkGet/256B-8     1521          1481          -2.63%
BenchmarkGet/512B-8     1836          1776          -3.27%
BenchmarkGet/1K-8       2393          2306          -3.64%
BenchmarkGet/2K-8       3364          3264          -2.97%
BenchmarkGet/4K-8       5413          5184          -4.23%
BenchmarkGet/8K-8       9116          8911          -2.25%
BenchmarkGet/16K-8      15947         15842         -0.66%
BenchmarkGet/32K-8      33585         32416         -3.48%

benchmark               old MB/s     new MB/s     speedup
BenchmarkGet/128B-8     91.25        93.61        1.03x
BenchmarkGet/256B-8     168.20       172.82       1.03x
BenchmarkGet/512B-8     278.82       288.26       1.03x
BenchmarkGet/1K-8       427.90       444.01       1.04x
BenchmarkGet/2K-8       608.78       627.40       1.03x
BenchmarkGet/4K-8       756.60       790.00       1.04x
BenchmarkGet/8K-8       898.63       919.31       1.02x
BenchmarkGet/16K-8      1027.37      1034.19      1.01x
BenchmarkGet/32K-8      975.67       1010.85      1.04x
```
These changes are not a definite proposal, but just an exploration... I find the results quite interesting. 
What do you think?

