### PR TITLE
inline hash function to save extra alloc

### DIFF
--- a/internal/utils.go
+++ b/internal/utils.go
@@ -2,7 +2,6 @@ package internal
 
 import (
 	"fmt"
-	"hash/fnv"
 	"os"
 	"path/filepath"
 	"sort"
@@ -10,10 +9,18 @@ import (
 	"strings"
 )
 
+const (
+	offset64 = 14695981039346656037
+	prime64  = 1099511628211
+)
+
 func Hash(key []byte) uint64 {
-	h := fnv.New64a()
-	h.Write(key)
-	return h.Sum64()
+	var s uint64 = offset64
+	for _, c := range key {
+		s ^= uint64(c)
+		s *= prime64
+	}
+	return s
 }
 
 func Exists(path string) bool {


### PR DESCRIPTION
Coming back to 1 alloc. Considering we aren't going to change the hash function, may be acceptable for the extra performance.

PR vs `master`:
```
benchmark               old ns/op     new ns/op     delta
BenchmarkGet/128B-8     869           897           +3.22%
BenchmarkGet/256B-8     915           899           -1.75%
BenchmarkGet/512B-8     1073          1066          -0.65%
BenchmarkGet/1K-8       1319          1265          -4.09%
BenchmarkGet/2K-8       1653          1590          -3.81%
BenchmarkGet/4K-8       2535          2426          -4.30%
BenchmarkGet/8K-8       3790          3877          +2.30%
BenchmarkGet/16K-8      6916          6819          -1.40%
BenchmarkGet/32K-8      13848         13310         -3.89%
BenchmarkPut/128B-8     4085          4100          +0.37%
BenchmarkPut/256B-8     5509          5185          -5.88%
BenchmarkPut/1K-8       12111         11729         -3.15%
BenchmarkPut/2K-8       22037         19836         -9.99%
BenchmarkPut/4K-8       38068         41755         +9.69%
BenchmarkPut/8K-8       70442         71665         +1.74%
BenchmarkPut/16K-8      132866        135559        +2.03%
BenchmarkPut/32K-8      263108        263390        +0.11%
BenchmarkScan-8         2895          2648          -8.53%

benchmark               old MB/s     new MB/s     speedup
BenchmarkGet/128B-8     147.26       142.62       0.97x
BenchmarkGet/256B-8     279.53       284.55       1.02x
BenchmarkGet/512B-8     476.99       480.15       1.01x
BenchmarkGet/1K-8       775.83       809.42       1.04x
BenchmarkGet/2K-8       1238.86      1287.82      1.04x
BenchmarkGet/4K-8       1615.63      1687.75      1.04x
BenchmarkGet/8K-8       2160.98      2112.60      0.98x
BenchmarkGet/16K-8      2368.90      2402.52      1.01x
BenchmarkGet/32K-8      2366.20      2461.82      1.04x
BenchmarkPut/128B-8     31.33        31.21        1.00x
BenchmarkPut/256B-8     46.46        49.37        1.06x
BenchmarkPut/1K-8       84.54        87.30        1.03x
BenchmarkPut/2K-8       92.93        103.25       1.11x
BenchmarkPut/4K-8       107.59       98.09        0.91x
BenchmarkPut/8K-8       116.29       114.31       0.98x
BenchmarkPut/16K-8      123.31       120.86       0.98x
BenchmarkPut/32K-8      124.54       124.41       1.00x

benchmark               old allocs     new allocs     delta
BenchmarkGet/128B-8     2              1              -50.00%
BenchmarkGet/256B-8     2              1              -50.00%
BenchmarkGet/512B-8     2              1              -50.00%
BenchmarkGet/1K-8       2              1              -50.00%
BenchmarkGet/2K-8       2              1              -50.00%
BenchmarkGet/4K-8       2              1              -50.00%
BenchmarkGet/8K-8       2              1              -50.00%
BenchmarkGet/16K-8      2              1              -50.00%
BenchmarkGet/32K-8      2              1              -50.00%
BenchmarkPut/128B-8     7              6              -14.29%
BenchmarkPut/256B-8     7              6              -14.29%
BenchmarkPut/1K-8       7              6              -14.29%
BenchmarkPut/2K-8       7              6              -14.29%
BenchmarkPut/4K-8       7              6              -14.29%
BenchmarkPut/8K-8       7              6              -14.29%
BenchmarkPut/16K-8      7              6              -14.29%
BenchmarkPut/32K-8      8              7              -12.50%
BenchmarkScan-8         35             35             +0.00%

benchmark               old bytes     new bytes     delta
BenchmarkGet/128B-8     168           160           -4.76%
BenchmarkGet/256B-8     296           288           -2.70%
BenchmarkGet/512B-8     584           576           -1.37%
BenchmarkGet/1K-8       1160          1152          -0.69%
BenchmarkGet/2K-8       2312          2304          -0.35%
BenchmarkGet/4K-8       4872          4864          -0.16%
BenchmarkGet/8K-8       9480          9472          -0.08%
BenchmarkGet/16K-8      18440         18432         -0.04%
BenchmarkGet/32K-8      40968         40960         -0.02%
BenchmarkPut/128B-8     209           193           -7.66%
BenchmarkPut/256B-8     210           194           -7.62%
BenchmarkPut/1K-8       218           202           -7.34%
BenchmarkPut/2K-8       229           213           -6.99%
BenchmarkPut/4K-8       249           233           -6.43%
BenchmarkPut/8K-8       291           280           -3.78%
BenchmarkPut/16K-8      373           356           -4.56%
BenchmarkPut/32K-8      537           523           -2.61%
BenchmarkScan-8         424           424           +0.00%
```
If you can confirm the benchmark (and my inline of `fnv.New64a+Write()+Sum64()` and consider this worth it, go ahead.  :)