### PR TITLE
Refactor and general tests for codec index

### DIFF
--- a/internal/codec_index.go
+++ b/internal/codec_index.go
@@ -8,15 +8,15 @@ import (
 )
 
 const (
-	Int32Size  = 4
-	Int64Size  = 8
-	FileIDSize = Int32Size
-	OffsetSize = Int64Size
-	SizeSize   = Int64Size
+	int32Size  = 4
+	int64Size  = 8
+	fileIDSize = int32Size
+	offsetSize = int64Size
+	sizeSize   = int64Size
 )
 
 func ReadBytes(r io.Reader) ([]byte, error) {
-	s := make([]byte, Int32Size)
+	s := make([]byte, int32Size)
 	_, err := io.ReadFull(r, s)
 	if err != nil {
 		return nil, err
@@ -31,7 +31,7 @@ func ReadBytes(r io.Reader) ([]byte, error) {
 }
 
 func WriteBytes(b []byte, w io.Writer) (int, error) {
-	s := make([]byte, Int32Size)
+	s := make([]byte, int32Size)
 	binary.BigEndian.PutUint32(s, uint32(len(b)))
 	n, err := w.Write(s)
 	if err != nil {
@@ -45,24 +45,24 @@ func WriteBytes(b []byte, w io.Writer) (int, error) {
 }
 
 func ReadItem(r io.Reader) (Item, error) {
-	buf := make([]byte, (FileIDSize + OffsetSize + SizeSize))
+	buf := make([]byte, (fileIDSize + offsetSize + sizeSize))
 	_, err := io.ReadFull(r, buf)
 	if err != nil {
 		return Item{}, err
 	}
 
 	return Item{
-		FileID: int(binary.BigEndian.Uint32(buf[:FileIDSize])),
-		Offset: int64(binary.BigEndian.Uint64(buf[FileIDSize:(FileIDSize + OffsetSize)])),
-		Size:   int64(binary.BigEndian.Uint64(buf[(FileIDSize + OffsetSize):])),
+		FileID: int(binary.BigEndian.Uint32(buf[:fileIDSize])),
+		Offset: int64(binary.BigEndian.Uint64(buf[fileIDSize:(fileIDSize + offsetSize)])),
+		Size:   int64(binary.BigEndian.Uint64(buf[(fileIDSize + offsetSize):])),
 	}, nil
 }
 
 func WriteItem(item Item, w io.Writer) (int, error) {
-	buf := make([]byte, (FileIDSize + OffsetSize + SizeSize))
-	binary.BigEndian.PutUint32(buf[:FileIDSize], uint32(item.FileID))
-	binary.BigEndian.PutUint64(buf[FileIDSize:(FileIDSize+OffsetSize)], uint64(item.Offset))
-	binary.BigEndian.PutUint64(buf[(FileIDSize+OffsetSize):], uint64(item.Size))
+	buf := make([]byte, (fileIDSize + offsetSize + sizeSize))
+	binary.BigEndian.PutUint32(buf[:fileIDSize], uint32(item.FileID))
+	binary.BigEndian.PutUint64(buf[fileIDSize:(fileIDSize+offsetSize)], uint64(item.Offset))
+	binary.BigEndian.PutUint64(buf[(fileIDSize+offsetSize):], uint64(item.Size))
 	n, err := w.Write(buf)
 	if err != nil {
 		return 0, err

--- a/internal/codec_index.go
+++ b/internal/codec_index.go
@@ -80,7 +80,7 @@ func writeItem(item Item, w io.Writer) (int, error) {
 	return n, nil
 }
 
-// ReadIndex reads a persisted from a io.Reader into a Tree
+// ReadIndex reads a persisted tree from a io.Reader into a Tree
 func ReadIndex(r io.Reader, t art.Tree) error {
 	for {
 		key, err := readKeyBytes(r)

--- a/internal/codec_index.go
+++ b/internal/codec_index.go
@@ -102,7 +102,7 @@ func ReadIndex(r io.Reader, t art.Tree) error {
 	return nil
 }
 
-// WriteIndex persist a Tree into a io.Writer
+// WriteIndex persists a Tree into a io.Writer
 func WriteIndex(t art.Tree, w io.Writer) (err error) {
 	t.ForEach(func(node art.Node) bool {
 		_, err = writeBytes(node.Key(), w)

--- a/internal/codec_index_test.go
+++ b/internal/codec_index_test.go
@@ -1,0 +1,91 @@
+package internal
+
+import (
+	"bytes"
+	"encoding/base64"
+	"testing"
+
+	"github.com/pkg/errors"
+	art "github.com/plar/go-adaptive-radix-tree"
+)
+
+const (
+	base64SampleTree = "AAAABGFiY2QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARhYmNlAAAAAQAAAAAAAAABAAAAAAAAAAEAAAAEYWJjZgAAAAIAAAAAAAAAAgAAAAAAAAACAAAABGFiZ2QAAAADAAAAAAAAAAMAAAAAAAAAAw=="
+)
+
+func TestWriteIndex(t *testing.T) {
+	at, expectedSerializedSize := getSampleTree()
+
+	var b bytes.Buffer
+	err := WriteIndex(at, &b)
+	if err != nil {
+		t.Fatalf("writing index failed: %v", err)
+	}
+	if b.Len() != expectedSerializedSize {
+		t.Fatalf("incorrect size of serialied index: expected %d, got: %d", expectedSerializedSize, b.Len())
+	}
+	sampleTreeBytes, _ := base64.StdEncoding.DecodeString(base64SampleTree)
+	if !bytes.Equal(b.Bytes(), sampleTreeBytes) {
+		t.Fatalf("unexpected serialization of the tree")
+	}
+}
+
+func TestReadIndex(t *testing.T) {
+	sampleTreeBytes, _ := base64.StdEncoding.DecodeString(base64SampleTree)
+	b := bytes.NewBuffer(sampleTreeBytes)
+
+	at := art.New()
+	err := ReadIndex(b, at)
+	if err != nil {
+		t.Fatalf("error while deserializing correct sample tree: %v", err)
+	}
+
+	atsample, _ := getSampleTree()
+	if atsample.Size() != at.Size() {
+		t.Fatalf("trees aren't the same size, expected %v, got %v", atsample.Size(), at.Size())
+	}
+	atsample.ForEach(func(node art.Node) bool {
+		_, found := at.Search(node.Key())
+		if !found {
+			t.Fatalf("expected node wasn't found: %s", node.Key())
+		}
+		return true
+	})
+}
+
+func TestReadCorruptedData(t *testing.T) {
+	sampleBytes, _ := base64.StdEncoding.DecodeString(base64SampleTree)
+	table := []struct {
+		name string
+		err  error
+		data []byte
+	}{
+		{name: "truncated-key-size-first-item", err: errTruncatedKeySize, data: sampleBytes[:2]},
+		{name: "truncated-key-data-second-item", err: errTruncatedKeyData, data: sampleBytes[:6]},
+		{name: "truncated-key-size-second-item", err: errTruncatedKeySize, data: sampleBytes[:(int32Size+4+fileIDSize+offsetSize+sizeSize)+2]},
+		{name: "truncated-key-data-second-item", err: errTruncatedKeyData, data: sampleBytes[:(int32Size+4+fileIDSize+offsetSize+sizeSize)+6]},
+		{name: "truncated-data", err: errTruncatedData, data: sampleBytes[:int32Size+4+(fileIDSize+offsetSize+sizeSize-3)]},
+	}
+
+	for i := range table {
+		t.Run(table[i].name, func(t *testing.T) {
+			bf := bytes.NewBuffer(table[i].data)
+
+			if err := ReadIndex(bf, art.New()); errors.Cause(err) != table[i].err {
+				t.Fatalf("expected %v, got %v", table[i].err, err)
+			}
+		})
+	}
+}
+
+func getSampleTree() (art.Tree, int) {
+	at := art.New()
+	keys := [][]byte{[]byte("abcd"), []byte("abce"), []byte("abcf"), []byte("abgd")}
+	expectedSerializedSize := 0
+	for i := range keys {
+		at.Insert(keys[i], Item{FileID: i, Offset: int64(i), Size: int64(i)})
+		expectedSerializedSize += int32Size + len(keys[i]) + fileIDSize + offsetSize + sizeSize
+	}
+
+	return at, expectedSerializedSize
+}


### PR DESCRIPTION
First step towards detect and solve data corruption. (#78)
I kept clean commits regarding changes.

Basically:
1) `codec_index.go`
- unexport things
- tiny rename
- add `.Cause` errors for reading bytes and item
2) `codec_index_test.go`
- test write and check with harcoded base64 ouput
- test read from harcoded output
- check corruption for multiple cases

I'll continue with further test cases of corruption that doesn't necessarily involve truncation, but incoherent or out of reasonable bound values. Then continue with recovery tool.

After finishing, we can do the same with the other codec.

Coverage for `codec_index.go` is 91% now. Does `codecov` only track coverage of two files?

This PR is mergable, so if review is OK you can merge and I'll continue in further PRs.