### PR TITLE
codec_index: check sizes, new tests for data corruption & refactor

### DIFF
--- a/bitcask.go
+++ b/bitcask.go
@@ -351,7 +351,7 @@ func (b *Bitcask) reopen() error {
 		}
 		defer f.Close()
 
-		if err := internal.ReadIndex(f, t); err != nil {
+		if err := internal.ReadIndex(f, t, b.config.maxKeySize, b.config.maxValueSize); err != nil {
 			return err
 		}
 	} else {

--- a/internal/codec_index.go
+++ b/internal/codec_index.go
@@ -46,18 +46,18 @@ func readKeyBytes(r io.Reader, maxKeySize int) ([]byte, error) {
 	return b, nil
 }
 
-func writeBytes(b []byte, w io.Writer) (int, error) {
+func writeBytes(b []byte, w io.Writer) error {
 	s := make([]byte, int32Size)
 	binary.BigEndian.PutUint32(s, uint32(len(b)))
-	n, err := w.Write(s)
+	_, err := w.Write(s)
 	if err != nil {
-		return n, err
+		return err
 	}
-	m, err := w.Write(b)
+	_, err = w.Write(b)
 	if err != nil {
-		return (n + m), err
+		return err
 	}
-	return (n + m), nil
+	return nil
 }
 
 func readItem(r io.Reader, maxValueSize int) (Item, error) {
@@ -78,16 +78,16 @@ func readItem(r io.Reader, maxValueSize int) (Item, error) {
 	}, nil
 }
 
-func writeItem(item Item, w io.Writer) (int, error) {
+func writeItem(item Item, w io.Writer) error {
 	buf := make([]byte, (fileIDSize + offsetSize + sizeSize))
 	binary.BigEndian.PutUint32(buf[:fileIDSize], uint32(item.FileID))
 	binary.BigEndian.PutUint64(buf[fileIDSize:(fileIDSize+offsetSize)], uint64(item.Offset))
 	binary.BigEndian.PutUint64(buf[(fileIDSize+offsetSize):], uint64(item.Size))
-	n, err := w.Write(buf)
+	_, err := w.Write(buf)
 	if err != nil {
-		return 0, err
+		return err
 	}
-	return n, nil
+	return nil
 }
 
 // ReadIndex reads a persisted from a io.Reader into a Tree
@@ -115,13 +115,13 @@ func ReadIndex(r io.Reader, t art.Tree, maxKeySize, maxValueSize int) error {
 // WriteIndex persists a Tree into a io.Writer
 func WriteIndex(t art.Tree, w io.Writer) (err error) {
 	t.ForEach(func(node art.Node) bool {
-		_, err = writeBytes(node.Key(), w)
+		err = writeBytes(node.Key(), w)
 		if err != nil {
 			return false
 		}
 
 		item := node.Value().(Item)
-		_, err := writeItem(item, w)
+		err := writeItem(item, w)
 		if err != nil {
 			return false
 		}


### PR DESCRIPTION
Continues in #78  direction:
- Make `sizes` in persisted data untrusted, so add checks.
- Add tests for cover this.
- Minor refactor to avoid returned values currently not used.

I want to note something in particular that I'm not 100% convinced yet.

The read `size`s are checked against the max sizes of the current `config`, or at least it seems reasonable to do so. But maybe this might not be the best/correct bound.

If the same database/index is ran with different configurations of bitcask, this might get interpreted as data corruption. In particular, if first a max-size value of 1024 is used, and then a 512. In the 512 runs, the 1024 values are out of bounds.

I not sure that is a reasonable scenario, but might happen to someone. We can leave it this way now, and maybe discuss about new flags for size bounds flags to decouple actual configuration with global configuration regarding max-sizes. Opinions?

