### PR TITLE
fix: check of persisted index values

### DIFF
--- a/bitcask.go
+++ b/bitcask.go
@@ -337,7 +337,7 @@ func (b *Bitcask) reopen() error {
 		}
 		defer f.Close()
 
-		if err := internal.ReadIndex(f, t, b.config.maxKeySize, b.config.maxValueSize); err != nil {
+		if err := internal.ReadIndex(f, t, b.config.maxKeySize); err != nil {
 			return err
 		}
 	} else {

--- a/internal/codec_index_test.go
+++ b/internal/codec_index_test.go
@@ -36,7 +36,7 @@ func TestReadIndex(t *testing.T) {
 	b := bytes.NewBuffer(sampleTreeBytes)
 
 	at := art.New()
-	err := ReadIndex(b, at, 1024, 1024)
+	err := ReadIndex(b, at, 1024)
 	if err != nil {
 		t.Fatalf("error while deserializing correct sample tree: %v", err)
 	}
@@ -74,7 +74,7 @@ func TestReadCorruptedData(t *testing.T) {
 			t.Run(table[i].name, func(t *testing.T) {
 				bf := bytes.NewBuffer(table[i].data)
 
-				if err := ReadIndex(bf, art.New(), 1024, 1024); errors.Cause(err) != table[i].err {
+				if err := ReadIndex(bf, art.New(), 1024); errors.Cause(err) != table[i].err {
 					t.Fatalf("expected %v, got %v", table[i].err, err)
 				}
 			})
@@ -91,21 +91,19 @@ func TestReadCorruptedData(t *testing.T) {
 		binary.BigEndian.PutUint32(overflowDataSize[int32Size+4+fileIDSize+offsetSize:], 1025)
 
 		table := []struct {
-			name         string
-			err          error
-			maxKeySize   int
-			maxValueSize int
-			data         []byte
+			name       string
+			err        error
+			maxKeySize int
+			data       []byte
 		}{
-			{name: "key-data-overflow", err: errKeySizeTooLarge, maxKeySize: 1024, maxValueSize: 1024, data: overflowKeySize},
-			{name: "item-data-overflow", err: errDataSizeTooLarge, maxKeySize: 1024, maxValueSize: 1024, data: overflowDataSize},
+			{name: "key-data-overflow", err: errKeySizeTooLarge, maxKeySize: 1024, data: overflowKeySize},
 		}
 
 		for i := range table {
 			t.Run(table[i].name, func(t *testing.T) {
 				bf := bytes.NewBuffer(table[i].data)
 
-				if err := ReadIndex(bf, art.New(), table[i].maxKeySize, table[i].maxValueSize); errors.Cause(err) != table[i].err {
+				if err := ReadIndex(bf, art.New(), table[i].maxKeySize); errors.Cause(err) != table[i].err {
 					t.Fatalf("expected %v, got %v", table[i].err, err)
 				}
 			})


### PR DESCRIPTION
Fixes a bug mentioned in #79.

There was a conceptually wrong check.
The maximum size of data isn't really in the `codec_index` world since only keys are saved there.
This check will be included when corruption in the *data* file will be done