### PR TITLE
cmd/bitcask: recovery tool

### DIFF
--- a/cmd/bitcask/recover.go
+++ b/cmd/bitcask/recover.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"os"
+
+	"github.com/prologic/bitcask"
+	"github.com/prologic/bitcask/internal/index"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var recoveryCmd = &cobra.Command{
+	Use:     "recover",
+	Aliases: []string{"recovery"},
+	Short:   "Analyzes and recovers the index file for corruption scenarios",
+	Long: `This analyze files to detect different forms of persistence corruption in 
+persisted files. It also allows to recover the files to the latest point of integrity.
+Recovered files have the .recovered extension`,
+	Args: cobra.ExactArgs(0),
+	Run: func(cmd *cobra.Command, args []string) {
+		path := viper.GetString("path")
+		dryRun := viper.GetBool("dry-run")
+		os.Exit(recover(path, dryRun))
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(recoveryCmd)
+	recoveryCmd.Flags().BoolP("dry-run", "n", false, "Will only check files health without applying recovery if unhealthy")
+	viper.BindPFlag("dry-run", recoveryCmd.Flags().Lookup("dry-run"))
+}
+
+func recover(path string, dryRun bool) int {
+	t, found, err := index.ReadFromFile(path, bitcask.DefaultMaxKeySize)
+	if err != nil && !index.IsIndexCorruption(err) {
+		log.WithError(err).Info("error while opening the index file")
+	}
+	if !found {
+		log.Info("index file doesn't exist, will be recreated on next run.")
+		return 0
+	}
+
+	if err == nil {
+		log.Debug("index file is not corrupted")
+		return 0
+	}
+	log.Debugf("index file is corrupted: %v", err)
+
+	if dryRun {
+		log.Debug("dry-run mode, not writing to a file")
+		return 0
+	}
+
+	fi, err := os.OpenFile("index.recovered", os.O_WRONLY|os.O_CREATE, 0600)
+	if err != nil {
+		log.WithError(err).Info("error while creating recovered index file")
+		return 1
+	}
+
+	// Leverage that t has the partiatially read tree even on corrupted files
+	err = index.WriteIndex(t, fi)
+	if err != nil {
+		log.WithError(err).Info("error while writing the recovered index file")
+
+		fi.Close()
+		return 1
+	}
+	err = fi.Close()
+	if err != nil {
+		log.WithError(err).Info("the recovered file index coudn't be saved correctly")
+	}
+	log.Debug("the index was recovered in the index.recovered new file")
+
+	return 0
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,36 @@
+package config
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"path/filepath"
+)
+
+// Config contains the bitcask configuration parameters
+type Config struct {
+	MaxDatafileSize int  `json:"max_datafile_size"`
+	MaxKeySize      int  `json:"max_key_size"`
+	MaxValueSize    int  `json:"max_value_size"`
+	Sync            bool `json:"sync"`
+}
+
+// Decode decodes a serialized configuration
+func Decode(path string) (*Config, error) {
+	var cfg Config
+
+	data, err := ioutil.ReadFile(filepath.Join(path, "config.json"))
+	if err != nil {
+		return nil, err
+	}
+
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, err
+	}
+
+	return &cfg, nil
+}
+
+// Encode encodes the configuration for storage
+func (c *Config) Encode() ([]byte, error) {
+	return json.Marshal(c)
+}

--- a/internal/data/codec.go
+++ b/internal/data/codec.go
@@ -1,4 +1,4 @@
-package internal
+package data
 
 import (
 	"bufio"
@@ -6,6 +6,7 @@ import (
 	"io"
 
 	"github.com/pkg/errors"
+	"github.com/prologic/bitcask/internal"
 )
 
 const (
@@ -27,7 +28,7 @@ type Encoder struct {
 
 // Encode takes any Entry and streams it to the underlying writer.
 // Messages are framed with a key-length and value-length prefix.
-func (e *Encoder) Encode(msg Entry) (int64, error) {
+func (e *Encoder) Encode(msg internal.Entry) (int64, error) {
 	var bufKeyValue = make([]byte, KeySize+ValueSize)
 	binary.BigEndian.PutUint32(bufKeyValue[:KeySize], uint32(len(msg.Key)))
 	binary.BigEndian.PutUint64(bufKeyValue[KeySize:KeySize+ValueSize], uint64(len(msg.Value)))
@@ -66,7 +67,7 @@ type Decoder struct {
 	r io.Reader
 }
 
-func (d *Decoder) Decode(v *Entry) (int64, error) {
+func (d *Decoder) Decode(v *internal.Entry) (int64, error) {
 	prefixBuf := make([]byte, KeySize+ValueSize)
 
 	_, err := io.ReadFull(d.r, prefixBuf)
@@ -91,7 +92,7 @@ func GetKeyValueSizes(buf []byte) (uint64, uint64) {
 	return uint64(actualKeySize), actualValueSize
 }
 
-func DecodeWithoutPrefix(buf []byte, valueOffset uint64, v *Entry) {
+func DecodeWithoutPrefix(buf []byte, valueOffset uint64, v *internal.Entry) {
 	v.Key = buf[:valueOffset]
 	v.Value = buf[valueOffset : len(buf)-checksumSize]
 	v.Checksum = binary.BigEndian.Uint32(buf[len(buf)-checksumSize:])

--- a/internal/data/datafile.go
+++ b/internal/data/datafile.go
@@ -1,4 +1,4 @@
-package internal
+package data
 
 import (
 	"fmt"
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/pkg/errors"
+	"github.com/prologic/bitcask/internal"
 	"golang.org/x/exp/mmap"
 )
 
@@ -119,7 +120,7 @@ func (df *Datafile) Size() int64 {
 	return df.offset
 }
 
-func (df *Datafile) Read() (e Entry, n int64, err error) {
+func (df *Datafile) Read() (e internal.Entry, n int64, err error) {
 	df.Lock()
 	defer df.Unlock()
 
@@ -131,7 +132,7 @@ func (df *Datafile) Read() (e Entry, n int64, err error) {
 	return
 }
 
-func (df *Datafile) ReadAt(index, size int64) (e Entry, err error) {
+func (df *Datafile) ReadAt(index, size int64) (e internal.Entry, err error) {
 	var n int
 
 	b := make([]byte, size)
@@ -155,7 +156,7 @@ func (df *Datafile) ReadAt(index, size int64) (e Entry, err error) {
 	return
 }
 
-func (df *Datafile) Write(e Entry) (int64, int64, error) {
+func (df *Datafile) Write(e internal.Entry) (int64, int64, error) {
 	if df.w == nil {
 		return -1, 0, ErrReadonly
 	}

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -1,0 +1,27 @@
+package index
+
+import (
+	"os"
+	"path"
+
+	art "github.com/plar/go-adaptive-radix-tree"
+	"github.com/prologic/bitcask/internal"
+)
+
+// ReadFromFile reads an index from a persisted file
+func ReadFromFile(filePath string, maxKeySize int) (art.Tree, bool, error) {
+	t := art.New()
+	if !internal.Exists(path.Join(filePath, "index")) {
+		return t, false, nil
+	}
+
+	f, err := os.Open(path.Join(filePath, "index"))
+	if err != nil {
+		return t, true, err
+	}
+	defer f.Close()
+	if err := readIndex(f, t, maxKeySize); err != nil {
+		return t, true, err
+	}
+	return t, true, nil
+}

--- a/options.go
+++ b/options.go
@@ -1,10 +1,6 @@
 package bitcask
 
-import (
-	"encoding/json"
-	"io/ioutil"
-	"path/filepath"
-)
+import "github.com/prologic/bitcask/internal/config"
 
 const (
 	// DefaultMaxDatafileSize is the default maximum datafile size in bytes
@@ -15,87 +11,34 @@ const (
 
 	// DefaultMaxValueSize is the default value size in bytes
 	DefaultMaxValueSize = 1 << 16 // 65KB
+
+	// DefaultSync is the default file synchronization action
+	DefaultSync = false
 )
 
 // Option is a function that takes a config struct and modifies it
-type Option func(*config) error
-
-type config struct {
-	maxDatafileSize int
-	maxKeySize      int
-	maxValueSize    int
-	sync            bool
-}
-
-func (c *config) MarshalJSON() ([]byte, error) {
-	return json.Marshal(struct {
-		MaxDatafileSize int  `json:"max_datafile_size"`
-		MaxKeySize      int  `json:"max_key_size"`
-		MaxValueSize    int  `json:"max_value_size"`
-		Sync            bool `json:"sync"`
-	}{
-		MaxDatafileSize: c.maxDatafileSize,
-		MaxKeySize:      c.maxKeySize,
-		MaxValueSize:    c.maxValueSize,
-		Sync:            c.sync,
-	})
-}
-
-func getConfig(path string) (*config, error) {
-	type Config struct {
-		MaxDatafileSize int  `json:"max_datafile_size"`
-		MaxKeySize      int  `json:"max_key_size"`
-		MaxValueSize    int  `json:"max_value_size"`
-		Sync            bool `json:"sync"`
-	}
-
-	var cfg Config
-
-	data, err := ioutil.ReadFile(filepath.Join(path, "config.json"))
-	if err != nil {
-		return nil, err
-	}
-
-	if err := json.Unmarshal(data, &cfg); err != nil {
-		return nil, err
-	}
-
-	return &config{
-		maxDatafileSize: cfg.MaxDatafileSize,
-		maxKeySize:      cfg.MaxKeySize,
-		maxValueSize:    cfg.MaxValueSize,
-		sync:            cfg.Sync,
-	}, nil
-}
-
-func newDefaultConfig() *config {
-	return &config{
-		maxDatafileSize: DefaultMaxDatafileSize,
-		maxKeySize:      DefaultMaxKeySize,
-		maxValueSize:    DefaultMaxValueSize,
-	}
-}
+type Option func(*config.Config) error
 
 // WithMaxDatafileSize sets the maximum datafile size option
 func WithMaxDatafileSize(size int) Option {
-	return func(cfg *config) error {
-		cfg.maxDatafileSize = size
+	return func(cfg *config.Config) error {
+		cfg.MaxDatafileSize = size
 		return nil
 	}
 }
 
 // WithMaxKeySize sets the maximum key size option
 func WithMaxKeySize(size int) Option {
-	return func(cfg *config) error {
-		cfg.maxKeySize = size
+	return func(cfg *config.Config) error {
+		cfg.MaxKeySize = size
 		return nil
 	}
 }
 
 // WithMaxValueSize sets the maximum value size option
 func WithMaxValueSize(size int) Option {
-	return func(cfg *config) error {
-		cfg.maxValueSize = size
+	return func(cfg *config.Config) error {
+		cfg.MaxValueSize = size
 		return nil
 	}
 }
@@ -103,8 +46,17 @@ func WithMaxValueSize(size int) Option {
 // WithSync causes Sync() to be called on every key/value written increasing
 // durability and safety at the expense of performance
 func WithSync(sync bool) Option {
-	return func(cfg *config) error {
-		cfg.sync = sync
+	return func(cfg *config.Config) error {
+		cfg.Sync = sync
 		return nil
+	}
+}
+
+func newDefaultConfig() *config.Config {
+	return &config.Config{
+		MaxDatafileSize: DefaultMaxDatafileSize,
+		MaxKeySize:      DefaultMaxKeySize,
+		MaxValueSize:    DefaultMaxValueSize,
+		Sync:            DefaultSync,
 	}
 }


### PR DESCRIPTION
In the #78 direction.
This is still a WIP since I've made multiple changes and would like second opinions.

1- new `recover` command on `cmd/bitcask`
This is an approximation where I'd prefer some early comments to finish it up.

Discussion 1.a: database configuration: _options_.
Now are hardcoded to default values, which is not correct. Ok, so why not calling `Open` that `getConfig`?. Two reasons: first, this command isn't interested in really doing all the work of opening the database; second, even if is done there isn't an API to get the read configuration.

I think an option would be making `getConfig` exported, but move it away from the `bitcask` package to not really expose it to clients; moving it to some `internal` subpackage that can be used within the project. Opinions?

Discussion 1.b: an `output` flag
I didn't create an output flag to choose the path and name of the recovered index file but just chose `recovered_index` as the default one. Opinions? One flag per possible output (in the future two files will be analyzed, datafile and index file).

2- refactored `internal` package
I considered that the `internal` package had many functions sharing the same name scope which felt quite odd. I created two `internal` sub-packages: `data` and `index`, leaving in the base `internal` package the models and utils/version etc. 

I think this makes more sense to not mix unexported things from `codec_index` with other parts of unrelated code in `internal`. We can rollback this, but I took advantage of and make this proposal. Sounds convincing?

I'll keep progress freezed until a round of discussion, to adjust things and close it up later for a final review.