### PR TITLE
fix test compilation

### DIFF
--- a/internal/index/codec_index_test.go
+++ b/internal/index/codec_index_test.go
@@ -19,7 +19,7 @@ func TestWriteIndex(t *testing.T) {
 	at, expectedSerializedSize := getSampleTree()
 
 	var b bytes.Buffer
-	err := WriteIndex(at, &b)
+	err := writeIndex(at, &b)
 	if err != nil {
 		t.Fatalf("writing index failed: %v", err)
 	}


### PR DESCRIPTION
Fix tiny problem which makes compilation error due to an unexported function.