### PR TITLE
Export method reopen

### DIFF
--- a/bitcask.go
+++ b/bitcask.go
@@ -280,7 +280,7 @@ func (b *Bitcask) put(key, value []byte) (int64, int64, error) {
 	return b.curr.Write(e)
 }
 
-func (b *Bitcask) reopen() error {
+func (b *Bitcask) Reopen() error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -383,7 +383,7 @@ func (b *Bitcask) Merge() error {
 	}
 
 	// And finally reopen the database
-	return b.reopen()
+	return b.Reopen()
 }
 
 // Open opens the database at the given path with optional options.
@@ -436,7 +436,7 @@ func Open(path string, options ...Option) (*Bitcask, error) {
 		return nil, err
 	}
 
-	if err := bitcask.reopen(); err != nil {
+	if err := bitcask.Reopen(); err != nil {
 		return nil, err
 	}
 

--- a/bitcask_test.go
+++ b/bitcask_test.go
@@ -133,6 +133,63 @@ func TestAll(t *testing.T) {
 	})
 }
 
+func TestReopen(t *testing.T) {
+	assert := assert.New(t)
+
+	testdir, err := ioutil.TempDir("", "bitcask")
+	assert.NoError(err)
+
+	t.Run("Reopen", func(t *testing.T) {
+		var (
+			db  *Bitcask
+			err error
+		)
+
+		t.Run("Open", func(t *testing.T) {
+			db, err = Open(testdir)
+			assert.NoError(err)
+		})
+
+		t.Run("Put", func(t *testing.T) {
+			err = db.Put([]byte("foo"), []byte("bar"))
+			assert.NoError(err)
+		})
+
+		t.Run("Get", func(t *testing.T) {
+			val, err := db.Get([]byte("foo"))
+			assert.NoError(err)
+			assert.Equal([]byte("bar"), val)
+		})
+
+		t.Run("Reopen", func(t *testing.T) {
+			err = db.Reopen()
+			assert.NoError(err)
+		})
+
+		t.Run("GetAfterReopen", func(t *testing.T) {
+			val, err := db.Get([]byte("foo"))
+			assert.NoError(err)
+			assert.Equal([]byte("bar"), val)
+		})
+
+		t.Run("PutAfterReopen", func(t *testing.T) {
+			err = db.Put([]byte("zzz"), []byte("foo"))
+			assert.NoError(err)
+		})
+
+		t.Run("GetAfterReopenAndPut", func(t *testing.T) {
+			val, err := db.Get([]byte("zzz"))
+			assert.NoError(err)
+			assert.Equal([]byte("foo"), val)
+		})
+
+		t.Run("Close", func(t *testing.T) {
+			err = db.Close()
+			assert.NoError(err)
+		})
+	})
+}
+
 func TestDeletedKeys(t *testing.T) {
 	assert := assert.New(t)
 


### PR DESCRIPTION
Example for test
```go
package main

import (
	"bytes"
	"crypto/rand"
	"github.com/google/uuid"
	"github.com/prologic/bitcask"
	"log"
	"os/exec"
	"time"
)

func writeMode() {
	db, err := bitcask.Open("bitcask")
	if err != nil {
		log.Fatal(err)
	}
	defer func() {
		if err := db.Close(); err != nil {
			log.Fatal(err)
		}
	}()

	go func() {
		t := time.NewTicker(5* time.Second)
		for range t.C {
			err := db.Lock()
			if err != nil {
				log.Fatal(err)
			}

			err = db.Merge()
			if err != nil {
				log.Fatal(err)
			}

			log.Println("Merge")

			err = db.Unlock()
			if err != nil {
				log.Fatal(err)
			}
		}
	}()

	u, err := uuid.Parse("4de92675-67aa-475f-b526-d9d6b49b2062")
	if err != nil {
		log.Fatal(err)
	}
	buf := []byte(`Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin nec ex purus. Suspendisse potenti. Vivamus lectus leo, luctus in semper eget, vulputate a quam. Maecenas a dolor tempor, porttitor quam ut, pharetra lectus. Nam auctor tortor et ex auctor, vel congue metus convallis. Etiam dictum justo eu velit tempor, et maximus massa ullamcorper. Donec at quam et orci condimentum sodales. Nunc dignissim, ex et pellentesque eleifend, libero leo suscipit mauris, ac mollis urna purus vehicula lacus. In nec nulla sed lorem hendrerit pulvinar. Morbi aliquam libero at massa malesuada, eget consequat sapien euismod.`)
	for {
		log.Println("Write")
		err = db.Put(u[:], buf)
		if err != nil {
			log.Fatal(err)
		}

		time.Sleep(time.Second)

		u = uuid.New()
		_, err = rand.Read(buf)
		if err != nil {
			log.Fatal(err)
		}
	}
}

func readMode() {
	db, err := bitcask.Open("bitcask_rsync")
	if err != nil {
		log.Fatal(err)
	}
	defer func() {
		if err := db.Close(); err != nil {
			log.Fatal(err)
		}
	}()

	u, err := uuid.Parse("4de92675-67aa-475f-b526-d9d6b49b2062")
	if err != nil {
		log.Fatal(err)
	}
	buf := []byte(`Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin nec ex purus. Suspendisse potenti. Vivamus lectus leo, luctus in semper eget, vulputate a quam. Maecenas a dolor tempor, porttitor quam ut, pharetra lectus. Nam auctor tortor et ex auctor, vel congue metus convallis. Etiam dictum justo eu velit tempor, et maximus massa ullamcorper. Donec at quam et orci condimentum sodales. Nunc dignissim, ex et pellentesque eleifend, libero leo suscipit mauris, ac mollis urna purus vehicula lacus. In nec nulla sed lorem hendrerit pulvinar. Morbi aliquam libero at massa malesuada, eget consequat sapien euismod.`)

	go func() {
		t := time.NewTicker(2* time.Second)
		for range t.C {
			err := db.Lock()
			if err != nil {
				log.Fatal(err)
			}

			cmd := exec.Command(
				"rsync",
				"-rtv",
				"bitcask/",
				"bitcask_rsync",
			)
			err = cmd.Run()
			if err != nil {
				log.Fatal(err)
			}

			err = db.Reopen()
			if err != nil {
				log.Fatal(err)
			}

			log.Println("Sync")

			err = db.Unlock()
			if err != nil {
				log.Fatal(err)
			}
		}
	}()

	for {
		d, err := db.Get(u[:])
		if err == bitcask.ErrKeyNotFound {
			log.Println("Not found yat")
			time.Sleep(time.Millisecond * 100)
			continue
		}
		if err != nil {
			log.Fatal(err)
		}

		log.Println("Read")
		if !bytes.Equal(d, buf) {
			log.Fatal("crash")
		}

		time.Sleep(time.Millisecond * 500)
	}
}

func main() {
	go writeMode()
	go readMode()

	select {}
}
```

Result:
```
2019/11/15 15:23:39 Not found yat
2019/11/15 15:23:39 Write
2019/11/15 15:23:39 Not found yat
2019/11/15 15:23:39 Not found yat
2019/11/15 15:23:39 Not found yat
2019/11/15 15:23:39 Not found yat
2019/11/15 15:23:39 Not found yat
2019/11/15 15:23:40 Not found yat
2019/11/15 15:23:40 Not found yat
2019/11/15 15:23:40 Not found yat
2019/11/15 15:23:40 Not found yat
2019/11/15 15:23:40 Not found yat
2019/11/15 15:23:40 Write
2019/11/15 15:23:40 Not found yat
2019/11/15 15:23:40 Not found yat
2019/11/15 15:23:40 Not found yat
2019/11/15 15:23:40 Not found yat
2019/11/15 15:23:40 Not found yat
2019/11/15 15:23:41 Not found yat
2019/11/15 15:23:41 Not found yat
2019/11/15 15:23:41 Not found yat
2019/11/15 15:23:41 Not found yat
2019/11/15 15:23:41 Write
2019/11/15 15:23:41 Not found yat
2019/11/15 15:23:41 Sync
2019/11/15 15:23:41 Read
```