### PR TITLE
Fix loadIndex to be deterministic

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,6 +2,7 @@
 #   Name or Organization <email address>
 # The email address is not required for organizations.
 
+Alain Gilbert <alain.gilbert.15@gmail.com>
 Awn Umar <awn@spacetime.dev>
 Christian Muehlhaeuser <muesli@gmail.com>
 Ignacio Hagopian <jsign.uy@gmail.com>

--- a/bitcask_test.go
+++ b/bitcask_test.go
@@ -133,6 +133,23 @@ func TestAll(t *testing.T) {
 	})
 }
 
+func TestReopen1(t *testing.T) {
+	assert := assert.New(t)
+	for i := 0; i < 10; i ++ {
+		testdir, _ := ioutil.TempDir("", "bitcask")
+		db, _ := Open(testdir, WithMaxDatafileSize(1))
+		_ = db.Put([]byte("foo"), []byte("bar"))
+		_ = db.Put([]byte("foo"), []byte("bar1"))
+		_ = db.Put([]byte("foo"), []byte("bar2"))
+		_ = db.Put([]byte("foo"), []byte("bar3"))
+		_ = db.Put([]byte("foo"), []byte("bar4"))
+		_ = db.Put([]byte("foo"), []byte("bar5"))
+		_ = db.Reopen()
+		val, _ := db.Get([]byte("foo"))
+		assert.Equal("bar5", string(val))
+	}
+}
+
 func TestReopen(t *testing.T) {
 	assert := assert.New(t)
 


### PR DESCRIPTION
I had some bad configs: "32 bytes max file size", and it was creating a lot of small files.
Then I realized that every time I would restart my app, the data was different.
I dig it a little to realize that the data was loaded from different files every time because the `loadIndex` function is not deterministic. (hashmap cannot be iterated in a deterministic manner)
So here is a fix.
Let me know if you have any questions/comments.